### PR TITLE
Add --version flag to CLI

### DIFF
--- a/jitx_emn_importer/emn_importer.py
+++ b/jitx_emn_importer/emn_importer.py
@@ -413,10 +413,13 @@ def main():
     """Command-line interface for EMN/IDF importer"""
     import argparse
 
+    from . import __version__
+
     parser = argparse.ArgumentParser(
         prog="emn-import",
         description="Import EMN/IDF/BDF files and generate JITX Python code",
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("emn_file", help="Path to the EMN/IDF/BDF file to import")
     parser.add_argument("class_name", help="Name prefix for the generated classes")
     parser.add_argument("output_file", help="Output Python file path")


### PR DESCRIPTION
## Summary
- Add `--version` flag to the `emn-import` CLI, sourced from `__version__` in `__init__.py`

```
$ emn-import --version
emn-import 1.0.0
```

## Test plan
- [x] `emn-import --version` prints `emn-import 1.0.0`
- [x] `emn-import --help` shows the version option
- [x] All 220 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)