### PR TITLE
Prepare repo for PyPI distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,24 @@ jobs:
 
       - name: Pytest with coverage
         run: pytest --cov=jitx_emn_importer --cov-branch --cov-report=term-missing
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: twine check dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish to PyPI
+
+# Triggered on tag pushes (e.g. `1.0.1` or `v1.0.1`). The build job runs
+# unconditionally; the publish job is gated on the `pypi` GitHub environment
+# and uses PyPI Trusted Publishing (OIDC), so no API token is stored in repo.
+#
+# Setup required (one-time, on PyPI):
+#   1. Create the project on PyPI (or claim the name).
+#   2. Add a Trusted Publisher pointing to this repo + workflow `publish.yml`
+#      + environment `pypi`.
+#   3. Create a `pypi` GitHub environment in the repo settings (no secrets needed).
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Check distribution metadata
+        run: twine check dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JITX Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,8 @@ version = "1.0.0"
 description = "EMN/IDF importer for JITX Python - converts mechanical CAD data to JITX geometry"
 readme = "README.md"
 requires-python = ">=3.12"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "JITX Inc."}
 ]
@@ -20,10 +21,10 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Adds the missing `LICENSE` file (MIT) so distributions ship with one.
- Modernizes `pyproject.toml` to PEP 639 license expressions (`license = \"MIT\"` + `license-files`) and drops the deprecated `License ::` classifier.
- Adds `.github/workflows/publish.yml` using PyPI Trusted Publishing (OIDC, no API tokens in the repo) — fires on tag pushes matching `1.2.3` or `v1.2.3`.
- Extends `ci.yml` with a `package` job that runs `python -m build` and `twine check` on every PR so packaging regressions surface early.

PyPI publishing is wired up but **dormant** until two one-time PyPI-side steps are done: register this repo + workflow as a Trusted Publisher, and create the \`pypi\` GitHub environment in the repo settings. The setup steps are documented in the comment block at the top of `publish.yml`.

## Notes

- README is intentionally unchanged (the project isn't actually publishing to PyPI yet).
- This PR is based on **#13** (\`bg/cleanup-ci-fixes\`); GitHub will retarget to \`main\` automatically once that lands.
- Tag pattern accepts both `1.0.1` and `v1.0.1` to accommodate the existing mixed-convention tags.

## Test plan

- [x] `python -m build` produces wheel + sdist; `twine check` passes both.
- [x] Wheel `METADATA` shows `License-Expression: MIT` and `License-File: LICENSE`; `licenses/LICENSE` is included in the wheel `dist-info`.
- [x] `pytest` — 110 passed, 12 skipped (no test regressions from the metadata change).
- [x] `emn-import --version` still prints `emn-import 1.0.0`.
- [ ] CI: `package` job builds and twine-checks on the PR.
- [ ] Publish workflow: cannot exercise without a tag push + PyPI side configuration; can be smoke-tested by pushing a pre-release tag once the Trusted Publisher is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)